### PR TITLE
Fix for path of events

### DIFF
--- a/src/originator.js
+++ b/src/originator.js
@@ -1,10 +1,6 @@
 export const originator = event => {
-  let host;
-  if (event.composed) {
-    [host] = event.composedPath();
-  } else {
-    [host] = event.path;
-  }
+  const [host] = event.composedPath();
+
   if (!host) {
     throw "Failed extracting originator";
   }


### PR DESCRIPTION
The access to `event.path` in originator.js causes an `Uncaught Exception (TypeError)` as it is `undefined`. The field `path` is not standard for objects of type `Event`, it is only implemented in Google Chrome and Chromium as far as I know.

This PR solves the issue by relying on the method `composedPath` which is part of the official spec of `Event`.

Note : only the first element of the array returned by `event.composedPath()` is used, and it differs from `event.target` only if the element emitting `event` is under an open shadow root. 